### PR TITLE
Cleanup a bit and allow for repeated parameters

### DIFF
--- a/.phpstorm.meta.php
+++ b/.phpstorm.meta.php
@@ -1,0 +1,63 @@
+<?php
+declare(strict_types=1);
+
+namespace PHPSTORM_META {
+
+    use Moka\Moka;
+
+    override(
+        Moka::phpunit(0),
+        map([
+            '' => '@'
+        ])
+    );
+
+    override(
+        Moka::prophecy(0),
+        map([
+            '' => '@'
+        ])
+    );
+
+    override(
+        Moka::mockery(0),
+        map([
+            '' => '@'
+        ])
+    );
+
+    override(
+        Moka::phake(0),
+        map([
+            '' => '@'
+        ])
+    );
+
+    override(
+        \Moka\Plugin\PHPUnit\moka(0),
+        map([
+            '' => '@'
+        ])
+    );
+
+    override(
+        \Moka\Plugin\Prophecy\moka(0),
+        map([
+            '' => '@'
+        ])
+    );
+
+    override(
+        \Moka\Plugin\Mockery\moka(0),
+        map([
+            '' => '@'
+        ])
+    );
+
+    override(
+        \Moka\Plugin\Phake\moka(0),
+        map([
+            '' => '@'
+        ])
+    );
+}

--- a/composer.json
+++ b/composer.json
@@ -30,6 +30,10 @@
     {
       "name": "Angelo Giuffredi",
       "email": "agiuffredi@gmail.com"
+    },
+    {
+      "name": "Alberto Villa",
+      "email": "villa.alberto@gmail.com"
     }
   ],
   "minimum-stability": "stable"

--- a/src/Error/DuplicateParametersFound.php
+++ b/src/Error/DuplicateParametersFound.php
@@ -1,9 +1,0 @@
-<?php
-
-declare(strict_types=1);
-
-namespace Giuffre\Sprint\Error;
-
-class DuplicateParametersFound extends \Error
-{
-}

--- a/src/Sprint.php
+++ b/src/Sprint.php
@@ -3,7 +3,6 @@ declare(strict_types=1);
 
 namespace Giuffre\Sprint;
 
-use Giuffre\Sprint\Error\DuplicateParametersFound;
 use Giuffre\Sprint\Error\NamedParametersMismatch;
 use Giuffre\Sprint\Template\NamedValues;
 use Giuffre\Sprint\Template\Template;
@@ -19,7 +18,6 @@ class Sprint
      * @param string $template
      * @param array[] ...$namedValues
      * @return string
-     * @throws DuplicateParametersFound
      * @throws NamedParametersMismatch
      */
     public static function sprint(string $template, array ...$namedValues): string

--- a/src/Template/NamedParameter.php
+++ b/src/Template/NamedParameter.php
@@ -14,7 +14,7 @@ use Giuffre\Sprint\Error\MalformedType;
 class NamedParameter
 {
     const PATTERN_NAME = '/\[(\w+)\]/';
-    const PATTERN_TYPE = '/(%)([\w]+)/';
+    const PATTERN_TYPE = '/%[\w]+/';
 
     /**
      * @var string

--- a/src/Template/NamedParameter.php
+++ b/src/Template/NamedParameter.php
@@ -13,6 +13,9 @@ use Giuffre\Sprint\Error\MalformedType;
  */
 class NamedParameter
 {
+    const PATTERN_NAME = '/\[(\w+)\]/';
+    const PATTERN_TYPE = '/(%)([\w]+)/';
+
     /**
      * @var string
      */
@@ -34,7 +37,7 @@ class NamedParameter
     public function extractName(): string
     {
         $matches = [];
-        preg_match('/\[(\w+)\]/', $this->fromMatch, $matches);
+        preg_match(self::PATTERN_NAME, $this->fromMatch, $matches);
         if (!array_key_exists(1, $matches) || 0 >= count($matches)) {
             throw new MalformedName(
                 sprintf('Could not extract a name from this string: %s', $this->fromMatch)
@@ -51,7 +54,7 @@ class NamedParameter
     public function extractType(): string
     {
         $matches = [];
-        preg_match('/(%)([\w]+)/', $this->fromMatch, $matches);
+        preg_match(self::PATTERN_TYPE, $this->fromMatch, $matches);
         if (!array_key_exists(0, $matches) || 0 >= count($matches)) {
             throw new MalformedType(
                 sprintf('Could not extract a type from this string: %s', $this->fromMatch)

--- a/src/Template/NamedParameter.php
+++ b/src/Template/NamedParameter.php
@@ -39,7 +39,7 @@ class NamedParameter
         preg_match(self::PATTERN_NAME, $this->fromMatch, $matches);
         if (!array_key_exists(1, $matches) || 0 >= count($matches)) {
             throw new MalformedName(
-                sprintf('Could not extract a name from this string: %s', $this->fromMatch)
+                sprintf('Cannot extract parameter name from match: %s', $this->fromMatch)
             );
         }
 
@@ -56,7 +56,7 @@ class NamedParameter
         preg_match(self::PATTERN_TYPE, $this->fromMatch, $matches);
         if (!array_key_exists(0, $matches) || 0 >= count($matches)) {
             throw new MalformedType(
-                sprintf('Could not extract a type from this string: %s', $this->fromMatch)
+                sprintf('Cannot extract parameter type from match: %s', $this->fromMatch)
             );
         }
 

--- a/src/Template/NamedParameter.php
+++ b/src/Template/NamedParameter.php
@@ -1,5 +1,4 @@
 <?php
-
 declare(strict_types=1);
 
 namespace Giuffre\Sprint\Template;

--- a/src/Template/NamedParameters.php
+++ b/src/Template/NamedParameters.php
@@ -10,9 +10,9 @@ namespace Giuffre\Sprint\Template;
 class NamedParameters extends \ArrayObject
 {
     /**
-     * @var array
+     * @var NamedParameter[]
      */
-    private $namedParameters;
+    private $namedParameters = [];
 
     /**
      * NamedParameters constructor.
@@ -20,20 +20,22 @@ class NamedParameters extends \ArrayObject
      */
     public function __construct(array $namedParameters)
     {
-        $this->namedParameters = $namedParameters;
-        $input = [];
-        foreach ($this->namedParameters as $namedParameter) {
-            $input[] = new NamedParameter($namedParameter);
+        foreach ($namedParameters as $namedParameter) {
+            $this->namedParameters[] = new NamedParameter($namedParameter);
         }
 
-        parent::__construct($input);
+        parent::__construct($this->namedParameters);
     }
 
     /**
-     * @return bool
+     * @return int
      */
-    public function hasDupes(): bool
+    public function parameterCount(): int
     {
-        return !(count($this->namedParameters) === count(array_unique($this->namedParameters)));
+        $names = array_map(function (NamedParameter $parameter) {
+            return $parameter->extractName();
+        }, $this->namedParameters);
+
+        return count(array_unique($names));
     }
 }

--- a/src/Template/NamedValues.php
+++ b/src/Template/NamedValues.php
@@ -24,4 +24,12 @@ class NamedValues extends \ArrayObject
 
         parent::__construct($formattedNamedValues);
     }
+
+    /**
+     * @return int
+     */
+    public function valueCount(): int
+    {
+        return $this->count();
+    }
 }

--- a/src/Template/TransformedObject.php
+++ b/src/Template/TransformedObject.php
@@ -1,5 +1,4 @@
 <?php
-
 declare(strict_types=1);
 
 namespace Giuffre\Sprint\Template;

--- a/src/Template/Transformer.php
+++ b/src/Template/Transformer.php
@@ -50,11 +50,7 @@ class Transformer implements TransformerInterface
         preg_match_all(self::PATTERN, $template, $namedParameters);
 
         $namedParameters = new NamedParameters($namedParameters[0]);
-        if ($namedParameters->hasDupes()) {
-            throw new DuplicateParametersFound('Named parameters must be occur at most once');
-        }
-
-        if (count($namedParameters) !== count($this->namedValues)) {
+        if ($namedParameters->parameterCount() !== $this->namedValues->valueCount()) {
             throw new NamedParametersMismatch('Placeholders and values count must be the same');
         }
 

--- a/src/Template/Transformer.php
+++ b/src/Template/Transformer.php
@@ -13,10 +13,7 @@ use Giuffre\Sprint\Error\NamedParametersMismatch;
  */
 class Transformer implements TransformerInterface
 {
-    /**
-     * @var string
-     */
-    private $pattern = '/(%)([\w]+)\[(\w+)\]/';
+    const PATTERN = '/(%)([\w]+)\[(\w+)\]/';
 
     /**
      * @var NamedValues
@@ -50,7 +47,7 @@ class Transformer implements TransformerInterface
     {
         $namedParameters = [];
         $template = (string)$this->originalTemplate;
-        preg_match_all($this->pattern, $template, $namedParameters);
+        preg_match_all(self::PATTERN, $template, $namedParameters);
 
         $namedParameters = new NamedParameters($namedParameters[0]);
         if ($namedParameters->hasDupes()) {

--- a/src/Template/Transformer.php
+++ b/src/Template/Transformer.php
@@ -1,5 +1,4 @@
 <?php
-
 declare(strict_types=1);
 
 namespace Giuffre\Sprint\Template;

--- a/src/Template/Transformer.php
+++ b/src/Template/Transformer.php
@@ -13,7 +13,7 @@ use Giuffre\Sprint\Error\NamedParametersMismatch;
  */
 class Transformer implements TransformerInterface
 {
-    const PATTERN = '/(%)([\w]+)\[(\w+)\]/';
+    const PATTERN = '/%[\w]+\[\w+\]/';
 
     /**
      * @var NamedValues

--- a/src/Template/Transformer.php
+++ b/src/Template/Transformer.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Giuffre\Sprint\Template;
 
-use Giuffre\Sprint\Error\DuplicateParametersFound;
 use Giuffre\Sprint\Error\NamedParametersMismatch;
 
 /**
@@ -40,7 +39,6 @@ class Transformer implements TransformerInterface
 
     /**
      * @return TransformedObject
-     * @throws DuplicateParametersFound
      * @throws NamedParametersMismatch
      */
     public function transform(): TransformedObject

--- a/src/Template/TransformerInterface.php
+++ b/src/Template/TransformerInterface.php
@@ -3,7 +3,6 @@ declare(strict_types=1);
 
 namespace Giuffre\Sprint\Template;
 
-use Giuffre\Sprint\Error\DuplicateParametersFound;
 use Giuffre\Sprint\Error\NamedParametersMismatch;
 
 /**
@@ -14,7 +13,6 @@ interface TransformerInterface
 {
     /**
      * @return TransformedObject
-     * @throws DuplicateParametersFound
      * @throws NamedParametersMismatch
      */
     public function transform(): TransformedObject;

--- a/tests/SprintTest.php
+++ b/tests/SprintTest.php
@@ -1,5 +1,4 @@
 <?php
-
 declare(strict_types=1);
 
 namespace Tests;

--- a/tests/SprintTest.php
+++ b/tests/SprintTest.php
@@ -9,12 +9,25 @@ use PHPUnit\Framework\TestCase;
 
 class SprintTest extends TestCase
 {
-    public function testSprint()
+    public function testSprintWithNamedParameters()
     {
         $result = Sprint::sprint(
             'Le mele sono %s[come] e di colore %s[colore]',
             ['colore' => 'verde'],
             ['come' => 'buone']
+        );
+
+        $this->assertEquals(
+            'Le mele sono buone e di colore verde',
+            $result
+        );
+    }
+
+    public function testSprintWithNamedParametersArray()
+    {
+        $result = Sprint::sprint(
+            'Le mele sono %s[come] e di colore %s[colore]',
+            ['colore' => 'verde', 'come' => 'buone']
         );
 
         $this->assertEquals(

--- a/tests/SprintTest.php
+++ b/tests/SprintTest.php
@@ -35,4 +35,32 @@ class SprintTest extends TestCase
             $result
         );
     }
+
+    public function testSprintWithOverriddenNamedValues()
+    {
+        $result = Sprint::sprint(
+            'Le mele sono %s[come] e di colore %s[colore]',
+            ['colore' => 'verde'],
+            ['come' => 'buone'],
+            ['colore' => 'rosso']
+        );
+
+        $this->assertEquals(
+            'Le mele sono buone e di colore rosso',
+            $result
+        );
+    }
+
+    public function testSprintWithOverriddenNamedValuesArray()
+    {
+        $result = Sprint::sprint(
+            'Le mele sono %s[come] e di colore %s[colore]',
+            ['colore' => 'verde', 'come' => 'buone', 'colore' => 'rosso']
+        );
+
+        $this->assertEquals(
+            'Le mele sono buone e di colore rosso',
+            $result
+        );
+    }
 }

--- a/tests/SprintTest.php
+++ b/tests/SprintTest.php
@@ -36,6 +36,32 @@ class SprintTest extends TestCase
         );
     }
 
+    public function testSprintWithRepeatedNamedParameters()
+    {
+        $result = Sprint::sprint(
+            '%s[disciplina] è grande, %s[disciplina] è forte',
+            ['disciplina' => 'Shaolin Kung Fu']
+        );
+
+        $this->assertEquals(
+            'Shaolin Kung Fu è grande, Shaolin Kung Fu è forte',
+            $result
+        );
+    }
+
+    public function testSprintWithRepeatedTypedNamedParameters()
+    {
+        $result = Sprint::sprint(
+            'Zero can be rendered as an integer (%d[number]) as well as a string ("%s[number]")',
+            ['number' => 0]
+        );
+
+        $this->assertEquals(
+            'Zero can be rendered as an integer (0) as well as a string ("0")',
+            $result
+        );
+    }
+
     public function testSprintWithOverriddenNamedValues()
     {
         $result = Sprint::sprint(

--- a/tests/Template/TransformerTest.php
+++ b/tests/Template/TransformerTest.php
@@ -1,21 +1,24 @@
 <?php
 declare(strict_types=1);
 
-namespace Tests\Transformer;
+namespace Tests\Template;
 
 use Giuffre\Sprint\Template\NamedValues;
 use Giuffre\Sprint\Template\Template;
 use Giuffre\Sprint\Template\Transformer;
-use function Moka\Plugin\PHPUnit\moka;
+use Moka\Traits\MokaCleanerTrait;
 use PHPUnit\Framework\TestCase;
+use function Moka\Plugin\PHPUnit\moka;
 
 class TransformerTest extends TestCase
 {
+    use MokaCleanerTrait;
+
     public function testConstructorSuccess()
     {
         $transformer = new Transformer(
             moka(Template::class)->stub([
-                '__toString' => 'The Apple is %[color] and its taste is %s[how]'
+                '__toString' => 'Apples are %s[color] and taste %s[how]'
             ]),
             moka(NamedValues::class)
         );
@@ -23,11 +26,11 @@ class TransformerTest extends TestCase
         $this->assertInstanceOf(Transformer::class, $transformer);
     }
 
-    public function testConstructorFail()
+    public function testConstructorFailure()
     {
         $transformer = new Transformer(
             moka(Template::class)->stub([
-                '__toString' => 'The Apple is %[color] and its taste is %s[how]'
+                '__toString' => 'Apples are %s[color] and taste %s[how]'
             ]),
             moka(NamedValues::class)
         );

--- a/tests/TransformerTest.php
+++ b/tests/TransformerTest.php
@@ -1,10 +1,5 @@
 <?php
-/**
- * Created by PhpStorm.
- * User: angelogiuffredi
- * Date: 9/2/17
- * Time: 11:55 AM
- */
+declare(strict_types=1);
 
 namespace Tests\Transformer;
 


### PR DESCRIPTION
You can now write something like `sprint('%s[color] is %s[color]', ['color' => 'blue'])`.